### PR TITLE
78-[Feature] PostCreatePage api 연동 

### DIFF
--- a/src/components/Common/index.ts
+++ b/src/components/Common/index.ts
@@ -1,1 +1,0 @@
-export * from "@components/Common/ActionBtn";

--- a/src/customTypes/post.ts
+++ b/src/customTypes/post.ts
@@ -1,20 +1,19 @@
 import { DEV_DEPENDENCIES_LIST } from "@constants/devDependenciesList";
 
-export type DevDependencies = {
-  dependency: (typeof DEV_DEPENDENCIES_LIST)[number];
-  version: string;
-}[];
+export type DevDependency = (typeof DEV_DEPENDENCIES_LIST)[number];
+
+export type DevDependencies = { dependency: DevDependency; version: string }[];
 
 export type TPost = {
   _id: string;
   title: string;
-  content: string;
+  detail: string;
   author: {
     _id: string;
     username: string;
   };
   code: string;
-  devDependencies: DevDependencies[];
+  devDependencies: DevDependencies;
   likesCount: number;
   viewsCount: number;
   scrapsCount: number;
@@ -30,7 +29,7 @@ export type TPostDetail = TPost & {
   isAuthor: boolean;
 };
 
-export type CommonPostRequestProps = Pick<TPost, "title" | "content" | "devDependencies" | "code"> & {
+export type CommonPostRequestProps = Pick<TPost, "title" | "detail" | "devDependencies" | "code"> & {
   postId: string;
 };
 

--- a/src/customTypes/postCreate.ts
+++ b/src/customTypes/postCreate.ts
@@ -1,16 +1,32 @@
-// 버전 데이터 인터페이스
-export type VersionData = {
+import { DEV_DEPENDENCIES_LIST } from "@constants/devDependenciesList";
+// types/post.ts
+// 폼에서 사용하는 버전 데이터 타입
+export type DevDependencies = {
   id: string;
   dependency: string;
   version: string;
 };
 
-// 폼 상태 인터페이스
+// API 요청 시 사용할 버전 데이터 타입
+export type DevDependencyRequest = {
+  dependency: (typeof DEV_DEPENDENCIES_LIST)[number];
+  version: string;
+};
+
+// 폼 상태 타입
 export type PostFormState = {
   title: string;
-  content: string;
-  code: string; // 코드 에디터 내용
-  devDependencies: VersionData[];
+  detail: string;
+  code: string;
+  devDependencies: DevDependencies[];
+};
+
+// API 요청 타입
+export type CreatePostRequestProps = {
+  title: string;
+  detail: string;
+  code: string;
+  devDependencies: DevDependencyRequest[];
 };
 
 // 각 액션별 페이로드 타입 정의
@@ -19,8 +35,8 @@ export type SetTitleAction = {
   payload: string;
 };
 
-export type SetContentAction = {
-  type: "SET_CONTENT";
+export type SetDetailAction = {
+  type: "SET_DETAIL";
   payload: string;
 };
 
@@ -54,7 +70,7 @@ export type ResetFormAction = {
 // 모든 가능한 액션 타입 통합
 export type PostFormAction =
   | SetTitleAction
-  | SetContentAction
+  | SetDetailAction
   | SetCodeAction
   | AddVersionAction
   | RemoveVersionAction
@@ -64,7 +80,7 @@ export type PostFormAction =
 // 초기 상태
 export const initialState: PostFormState = {
   title: "",
-  content: "",
+  detail: "",
   code: "",
   devDependencies: [{ id: "1", dependency: "", version: "" }]
 };

--- a/src/hooks/useCreatePost.ts
+++ b/src/hooks/useCreatePost.ts
@@ -1,5 +1,36 @@
-// import { createPost } from "@/services/post/createPost";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createPost } from "@services/post/createPost";
+import { CommonPostRequestProps } from "@customTypes/post";
 
-// export const useCreatePost = () => {
+type CreatePostRequestProps = Pick<CommonPostRequestProps, "title" | "detail" | "devDependencies" | "code">;
 
-// };
+export const useCreatePost = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["post", "create"],
+    mutationFn: (data: CreatePostRequestProps) => {
+      // 요청 전 데이터 확인
+      console.log("Mutation Request Data:", {
+        title: data.title,
+        detail: data.detail,
+        code: data.code,
+        devDependencies: data.devDependencies
+      });
+      return createPost(data);
+    },
+    onSuccess: (data) => {
+      console.log("Mutation Success Data:", data);
+      // 게시물 목록 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: ["posts"] });
+      // 새로운 게시물을 캐시에 직접 추가
+      queryClient.setQueryData(["post", data._id], data);
+    },
+    onError: (error: Error) => {
+      console.error("Mutation Error:", {
+        message: error.message,
+        stack: error.stack
+      });
+    }
+  });
+};

--- a/src/services/post/createPost.ts
+++ b/src/services/post/createPost.ts
@@ -4,7 +4,7 @@ import axiosInstance from "@services/axiosInstance";
 import { AccessTokenStorage } from "@utils/localStorage";
 import axios, { AxiosError } from "axios";
 
-type CreatePostRequestProps = Pick<CommonPostRequestProps, "title" | "content" | "devDependencies" | "code">;
+type CreatePostRequestProps = Pick<CommonPostRequestProps, "title" | "detail" | "devDependencies" | "code">;
 
 type CreatePostResponseProps = Omit<TPost, "author"> & {
   author: string;

--- a/src/utils/postCreate/postFormReducer.ts
+++ b/src/utils/postCreate/postFormReducer.ts
@@ -2,7 +2,7 @@ import { PostFormState, PostFormAction } from "@/customTypes/postCreate";
 
 export const initialState: PostFormState = {
   title: "",
-  content: "",
+  detail: "",
   code: "",
   devDependencies: [{ id: "1", dependency: "", version: "" }]
 };
@@ -27,9 +27,9 @@ const handlers = {
     ...state,
     title: payload
   }),
-  SET_CONTENT: (state: PostFormState, payload: string): PostFormState => ({
+  SET_DETAIL: (state: PostFormState, payload: string): PostFormState => ({
     ...state,
-    content: payload
+    detail: payload
   }),
   SET_CODE: (state: PostFormState, payload: string): PostFormState => ({
     ...state,
@@ -62,8 +62,8 @@ export const postFormReducer = (state: PostFormState, action: PostFormAction): P
   switch (action.type) {
     case "SET_TITLE":
       return handlers.SET_TITLE(state, action.payload);
-    case "SET_CONTENT":
-      return handlers.SET_CONTENT(state, action.payload);
+    case "SET_DETAIL":
+      return handlers.SET_DETAIL(state, action.payload);
     case "SET_CODE":
       return handlers.SET_CODE(state, action.payload);
     case "ADD_VERSION":
@@ -91,8 +91,8 @@ export const validateForm = (state: PostFormState) => {
   if (!state.title.trim()) {
     errors.title = "제목을 입력해주세요.";
   }
-  if (!state.content.trim()) {
-    errors.content = "내용을 입력해주세요.";
+  if (!state.detail.trim()) {
+    errors.detail = "내용을 입력해주세요.";
   }
   if (!state.code.trim()) {
     errors.code = "코드를 입력해주세요.";


### PR DESCRIPTION
## #️⃣연관된 이슈
<!-- ex) #이슈번호, #이슈번호 -->
#78

## 📝작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
1. PostCreatePage 글쓰기 기능 구현 
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/3da9df98-c401-4984-9804-6ab5d62c95d8">
<img width="919" alt="image" src="https://github.com/user-attachments/assets/a884735e-0bff-4791-a88f-0bad0ccdc038">
<img width="938" alt="image" src="https://github.com/user-attachments/assets/273500f2-2cd2-40e6-8bb4-e09ab4733961">

### 스크린샷 (선택)## 💬리뷰 요구사항(선택)> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!--  ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

