### PR TITLE
95 feature mainsection  api

### DIFF
--- a/src/components/Common/PostListIcon.tsx
+++ b/src/components/Common/PostListIcon.tsx
@@ -1,7 +1,7 @@
-import { DevDependencies } from "@customTypes/post";
+import { DevDependency } from "@customTypes/post";
 import { devIconsDocs } from "@constants/devIconUrls";
 type PostListIconProps = {
-  devDependencies: DevDependencies;
+  devDependencies: DevDependency;
 };
 export const PostListIcon = ({ devDependencies }: PostListIconProps) => {
   return <div className={`h-14 w-14 bg-contain ${devIconsDocs[devDependencies].iconUrl}`}></div>;

--- a/src/components/Common/PostListItem.tsx
+++ b/src/components/Common/PostListItem.tsx
@@ -31,7 +31,7 @@ export const PostListItem = ({ postItem, ranked }: { postItem: TPost; ranked?: n
         </div>
       )}
       <div className="flex w-full gap-3 border-b-2 border-solid border-primary border-opacity-40 px-1 py-2.5">
-        <PostListIcon devDependencies={postItem.devDependencies[0]} />
+        <PostListIcon devDependencies={postItem.devDependencies[0].dependency} />
         <div className="flex flex-col gap-2.5">
           <div className="flex gap-2">
             <div className="text-24">{postItem.title}</div>
@@ -41,7 +41,7 @@ export const PostListItem = ({ postItem, ranked }: { postItem: TPost; ranked?: n
             {postItem.devDependencies.map((v, i) => {
               return (
                 <div className="rounded bg-lightgray px-2 py-1 text-14 text-black" key={i}>
-                  {v}
+                  {v.dependency}
                 </div>
               );
             })}

--- a/src/components/MainPage/MainBanner.tsx
+++ b/src/components/MainPage/MainBanner.tsx
@@ -1,36 +1,33 @@
-type MainBannerProps = { bannerType: "Question" | "MostViewedPosts" | "MostViewedTodayPosts" | "BestReviewer" };
+import { ReactNode } from "react";
+import { Link } from "react-router-dom";
 
-const bannerPreset = {
-  Question: {
-    color: "bg-secondary",
-    bannerTitle: "궁금한 것 질문하기!"
-  },
-  MostViewedPosts: {
-    color: "bg-purple",
-    bannerTitle: "역대 최다 조회수!"
-  },
-  MostViewedTodayPosts: {
-    color: "bg-skyblue",
-    bannerTitle: "오늘의 인기 질문"
-  },
-  BestReviewer: {
-    color: "bg-lightgreen",
-    bannerTitle: "베스트 리뷰어!"
-  }
+type MainBannerProps = {
+  bannerPreset: {
+    type: string;
+    color: string;
+    bannerTitle: string;
+    defaultContent: ReactNode;
+  };
+  bannerData: {
+    content: ReactNode;
+    link: string;
+  };
 };
 
-const MainBanner = ({ bannerType }: MainBannerProps) => {
+const MainBanner = ({ bannerPreset, bannerData }: MainBannerProps) => {
+  const inner = bannerData.content === "" ? bannerPreset.defaultContent : bannerData.content;
   return (
-    <div
-      className={`flex h-52 w-80 flex-col justify-between rounded-lg p-5 pb-10 text-white-pure shadow ${bannerPreset[bannerType].color}`}
+    <Link
+      to={bannerData.link}
+      className={`flex h-52 w-80 flex-col justify-between rounded-lg p-5 pb-10 text-white-pure shadow transition-all hover:scale-105 ${bannerPreset.color}`}
     >
       <div className="flex flex-col gap-7">
-        <div className="text-16">{bannerPreset[bannerType].bannerTitle}</div>
-        <div className="text-24">asdf</div>
+        <div className="text-16">{bannerPreset.bannerTitle}</div>
+        <div className="text-24">{inner}</div>
       </div>
-      {bannerType === "Question" && <div className="flex justify-end text-24">질문하기-&gt;</div>}
-      {bannerType === "BestReviewer" && <div className="flex justify-start text-24">작성글 확인하기</div>}
-    </div>
+      {bannerPreset.type === "Question" && <div className="flex justify-end text-24">질문하기-&gt;</div>}
+      {bannerPreset.type === "BestReviewer" && <div className="flex justify-start text-24">작성글 확인하기</div>}
+    </Link>
   );
 };
 

--- a/src/components/MainPage/MainBannerSkeleton.tsx
+++ b/src/components/MainPage/MainBannerSkeleton.tsx
@@ -1,0 +1,13 @@
+import { Loading } from "@components/Common/Loading";
+
+export const MainBannerSkeleton = () => {
+  return (
+    <>
+      {[1, 2, 3, 4].map((v) => (
+        <div key={v} className={`flex h-52 w-80 rounded-lg bg-black opacity-20 shadow`}>
+          <Loading />
+        </div>
+      ))}
+    </>
+  );
+};

--- a/src/components/MainPage/MainBannerWrap.tsx
+++ b/src/components/MainPage/MainBannerWrap.tsx
@@ -1,0 +1,95 @@
+import { useSuspenseQueries } from "@tanstack/react-query";
+import MainBanner from "@components/MainPage/MainBanner";
+import { getMostViewedPosts, GetMostViewedPostsResponseProps } from "@services/post/getMostViewedPosts";
+import { getMostViewedTodayPosts } from "@services/post/getMostViewedTodayPosts";
+import { getUserRankings, GetUserRankingsResponseProps } from "@services/user/getUserRankings";
+
+type BannerPreset = {
+  type: string;
+  color: string;
+  bannerTitle: string;
+  defaultContent: React.ReactNode;
+};
+
+const bannerPreset: BannerPreset[] = [
+  {
+    type: "Question",
+    color: "bg-secondary",
+    bannerTitle: "궁금한 것 질문하기!",
+    defaultContent: (
+      <>
+        궁금한 내용이 있다면
+        <br />
+        지금 바로 물어보세요
+      </>
+    )
+  },
+  {
+    type: "MostViewedPosts",
+    color: "bg-purple",
+    bannerTitle: "역대 최다 조회수!",
+    defaultContent: ""
+  },
+  {
+    type: "MostViewedTodayPosts",
+    color: "bg-skyblue",
+    bannerTitle: "오늘의 인기 질문",
+    defaultContent: ""
+  },
+  { type: "BestReviewer", color: "bg-lightgreen", bannerTitle: "베스트 리뷰어!", defaultContent: "" }
+];
+
+export const MainBannerWrap = () => {
+  const [mostViewedPosts, mostViewedTodayPosts, bestReviewer] = useSuspenseQueries({
+    queries: [
+      {
+        queryKey: ["mostViewedPosts"],
+        queryFn: () => getMostViewedPosts({ limit: 1 }),
+        select: (data: GetMostViewedPostsResponseProps) => data[0]
+      },
+      {
+        queryKey: ["mostViewedTodayPosts"],
+        queryFn: getMostViewedTodayPosts
+      },
+      {
+        queryKey: ["bestReviewer"],
+        queryFn: () => getUserRankings({ page: 1, limit: 1 }),
+        select: (data: GetUserRankingsResponseProps) => data.userRanking[0]
+      }
+    ]
+  });
+
+  if (mostViewedPosts.isError || mostViewedTodayPosts.isError || bestReviewer.isError) {
+    return <div>에러발생</div>;
+  }
+
+  type BannerData = {
+    content: React.ReactNode;
+    link: string;
+  };
+
+  const bannerData: BannerData[] = [
+    { content: "", link: "/post/create" },
+    { content: mostViewedPosts.data.title, link: `/post/${mostViewedPosts.data._id}` },
+    { content: mostViewedTodayPosts.data.title, link: `/post/${mostViewedTodayPosts.data._id}` },
+    {
+      content: (
+        <>
+          받은 추천 수 {bestReviewer.data.totalThumbsCount}회 <br />
+          {bestReviewer.data.totalThumbsCount}님
+        </>
+      ),
+      link: `/post/user/${bestReviewer.data.userId}`
+    }
+  ];
+  {
+    bannerPreset.map((preset, i) => <MainBanner key={preset.type} bannerPreset={preset} bannerData={bannerData[i]} />);
+  }
+  return (
+    <>
+      {bannerPreset.map((type, i) => (
+        <MainBanner key={i} bannerPreset={type} bannerData={bannerData[i]} />
+      ))}
+    </>
+  );
+};

--- a/src/components/MainPage/MainSection.tsx
+++ b/src/components/MainPage/MainSection.tsx
@@ -1,16 +1,12 @@
-import MainBanner from "@components/MainPage/MainBanner";
+import { MainBannerWrap } from "@components/MainPage/MainBannerWrap";
 import { Suspense } from "react";
-
+import { MainBannerSkeleton } from "@components/MainPage/MainBannerSkeleton";
 export const MainSection = () => {
-  const bannerType = ["Question", "MostViewedPosts", "MostViewedTodayPosts", "BestReviewer"];
-
   return (
     <div className="bg-lightpurple flex-center">
       <div className="flex max-w gap-10 px-10 py-12">
-        <Suspense fallback={<div>Loading...</div>}>
-          {bannerType.map((type, i) => (
-            <MainBanner key={i} bannerType={type} />
-          ))}
+        <Suspense fallback={<MainBannerSkeleton />}>
+          <MainBannerWrap />
         </Suspense>
       </div>
     </div>

--- a/src/components/MainPage/PopularPostSection.tsx
+++ b/src/components/MainPage/PopularPostSection.tsx
@@ -7,8 +7,12 @@ export const PopularPostSection = () => {
     {
       _id: "1",
       title: "React Router를 사용해 navigate하는 방법이 뭔가요?",
-      devDependencies: ["React", "JavaScript"],
-      content: "React Router를 사용해 navigate하는 방법이 뭔가요?",
+      devDependencies: [
+        { dependency: "React", version: "1.16.1" },
+        { dependency: "JavaScript", version: "1.16.1" }
+      ],
+      code: "",
+      detail: "React Router를 사용해 navigate하는 방법이 뭔가요?",
       author: { _id: "2", username: "shlee9999" },
       likesCount: 2352,
       viewsCount: 17854,
@@ -21,8 +25,12 @@ export const PopularPostSection = () => {
     {
       _id: "1",
       title: "React Router를 사용해 navigate하는 방법이 뭔가요?",
-      devDependencies: ["C#", "JavaScript"],
-      content: "React Router를 사용해 navigate하는 방법이 뭔가요?",
+      devDependencies: [
+        { dependency: "C#", version: "1.16.1" },
+        { dependency: "JavaScript", version: "1.16.1" }
+      ],
+      code: "",
+      detail: "React Router를 사용해 navigate하는 방법이 뭔가요?",
       author: { _id: "2", username: "shlee9999" },
       likesCount: 2352,
       viewsCount: 17854,
@@ -35,8 +43,12 @@ export const PopularPostSection = () => {
     {
       _id: "1",
       title: "React Router를 사용해 navigate하는 방법이 뭔가요?",
-      devDependencies: ["Sass", "JavaScript"],
-      content: "React Router를 사용해 navigate하는 방법이 뭔가요?",
+      devDependencies: [
+        { dependency: "Sass", version: "1.16.1" },
+        { dependency: "JavaScript", version: "1.16.1" }
+      ],
+      code: "",
+      detail: "React Router를 사용해 navigate하는 방법이 뭔가요?",
       author: { _id: "2", username: "shlee9999" },
       likesCount: 2352,
       viewsCount: 17854,

--- a/src/components/MainPage/RecentPostSection.tsx
+++ b/src/components/MainPage/RecentPostSection.tsx
@@ -7,7 +7,10 @@ export const RecentPostSection = () => {
     {
       _id: "1",
       title: "React Router를 사용해 navigate하는 방법이 뭔가요?",
-      devDependencies: ["React", "JavaScript"],
+      devDependencies: [
+        { dependency: "React", version: "1.16.1" },
+        { dependency: "JavaScript", version: "1.16.1" }
+      ],
       content: "React Router를 사용해 navigate하는 방법이 뭔가요?",
       author: { _id: "2", username: "shlee9999" },
       likesCount: 2352,
@@ -21,7 +24,10 @@ export const RecentPostSection = () => {
     {
       _id: "1",
       title: "React Router를 사용해 navigate하는 방법이 뭔가요?",
-      devDependencies: ["React", "JavaScript"],
+      devDependencies: [
+        { dependency: "C#", version: "1.16.1" },
+        { dependency: "JavaScript", version: "1.16.1" }
+      ],
       content: "React Router를 사용해 navigate하는 방법이 뭔가요?",
       author: { _id: "2", username: "shlee9999" },
       likesCount: 2352,
@@ -35,7 +41,10 @@ export const RecentPostSection = () => {
     {
       _id: "1",
       title: "React Router를 사용해 navigate하는 방법이 뭔가요?",
-      devDependencies: ["React", "JavaScript"],
+      devDependencies: [
+        { dependency: "Sass", version: "1.16.1" },
+        { dependency: "JavaScript", version: "1.16.1" }
+      ],
       content: "React Router를 사용해 navigate하는 방법이 뭔가요?",
       author: { _id: "2", username: "shlee9999" },
       likesCount: 2352,

--- a/src/components/MainPage/SubBanner.tsx
+++ b/src/components/MainPage/SubBanner.tsx
@@ -6,8 +6,12 @@ export const SubBanner = ({ color }: { color: "secondary" | "lightgreen" }) => {
     {
       _id: "1",
       title: "React Router를 사용해 navigate하는 방법이 뭔가요?",
-      devDependencies: ["React", "JavaScript"],
-      content: "React Router를 사용해 navigate하는 방법이 뭔가요?",
+      devDependencies: [
+        { dependency: "Sass", version: "1.16.1" },
+        { dependency: "JavaScript", version: "1.16.1" }
+      ],
+      code: "",
+      detail: "React Router를 사용해 navigate하는 방법이 뭔가요?",
       author: { _id: "2", username: "shlee9999" },
       likesCount: 2352,
       viewsCount: 17854,
@@ -20,22 +24,12 @@ export const SubBanner = ({ color }: { color: "secondary" | "lightgreen" }) => {
     {
       _id: "1",
       title: "React Router를 사용해 navigate하는 방법이 뭔가요?",
-      devDependencies: ["React", "JavaScript"],
-      content: "React Router를 사용해 navigate하는 방법이 뭔가요?",
-      author: { _id: "2", username: "shlee9999" },
-      likesCount: 2352,
-      viewsCount: 17854,
-      scrapsCount: 1234,
-      commentsCount: 50,
-      createdAt: "2024-10-28T02:13:20.475+00:00",
-      updatedAt: "2024-10-28T02:13:20.475+00:00",
-      __v: 1
-    },
-    {
-      _id: "1",
-      title: "React Router를 사용해 navigate하는 방법이 뭔가요?",
-      devDependencies: ["React", "JavaScript"],
-      content: "React Router를 사용해 navigate하는 방법이 뭔가요?",
+      devDependencies: [
+        { dependency: "Sass", version: "1.16.1" },
+        { dependency: "JavaScript", version: "1.16.1" }
+      ],
+      code: "",
+      detail: "React Router를 사용해 navigate하는 방법이 뭔가요?",
       author: { _id: "2", username: "shlee9999" },
       likesCount: 2352,
       viewsCount: 17854,
@@ -55,7 +49,7 @@ export const SubBanner = ({ color }: { color: "secondary" | "lightgreen" }) => {
       className={`relative flex ${bgColors[color]} h-52 w-[48%] flex-col justify-between rounded-lg p-5 pb-10 text-white-pure shadow`}
     >
       <div
-        className={`${devIconsDocs[data[0].devDependencies[0]].bgUrl} absolute bottom-0 left-0 h-32 w-32 bg-contain bg-center bg-no-repeat`}
+        className={`${devIconsDocs[data[0].devDependencies[0].dependency].bgUrl} absolute bottom-0 left-0 h-32 w-32 bg-contain bg-center bg-no-repeat`}
       ></div>
       <div className="text-28">{data[0].title}</div>
     </div>

--- a/src/constants/devIconUrls.ts
+++ b/src/constants/devIconUrls.ts
@@ -1,7 +1,7 @@
-import { DevDependencies } from "@customTypes/post";
+import { DevDependency } from "@customTypes/post";
 
 type DevIconsDocs = {
-  [key in DevDependencies]: {
+  [key in DevDependency]: {
     bgUrl: string;
     iconUrl: string;
   };

--- a/src/customTypes/userInfo.ts
+++ b/src/customTypes/userInfo.ts
@@ -1,7 +1,7 @@
 import { GROUP_LIST } from "@constants/groupList";
 
 export type UserInfo = {
-  id: string;
+  userId: string;
   username: string;
   group: (typeof GROUP_LIST)[keyof typeof GROUP_LIST];
 };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -35,6 +35,10 @@ export const router = createBrowserRouter([
         element: <PostPage />
       },
       {
+        path: "/post/user/:id",
+        element: <PostPage />
+      },
+      {
         path: "/post/:id",
         element: <PostDetailPage />
       },

--- a/src/services/post/getMostViewedPosts.ts
+++ b/src/services/post/getMostViewedPosts.ts
@@ -8,7 +8,7 @@ import axios, { AxiosError } from "axios";
 // 기본 limit은 1로 한 개만 전송됩니다.
 type GetMostViewedPostsRequestProps = Partial<Pick<PaginationRequestProps, "limit">>;
 
-type GetMostViewedPostsResponseProps = TPost[];
+export type GetMostViewedPostsResponseProps = TPost[];
 
 export async function getMostViewedPosts({
   limit

--- a/src/services/user/getUserRankings.ts
+++ b/src/services/user/getUserRankings.ts
@@ -6,7 +6,7 @@ import axios, { AxiosError } from "axios";
 
 type GetUserRankingsRequestProps = PaginationRequestProps;
 
-type GetUserRankingsResponseProps = {
+export type GetUserRankingsResponseProps = {
   currentPage: number;
   totalPages: number;
   userRanking: (UserInfo & {


### PR DESCRIPTION
## #️⃣연관된 이슈
#95 


## 📝작업 내용
- MainSection API 연결
- MainBanner 스켈레톤 컴포넌트 추가
- MainBanner 로딩 중 스켈레톤 컴포넌트 표시
- UserInfo 타입이 API 반환타입과 일치하지 않는 내용 수정
- TPost 타입이 변경됨에 따라 관련 컴포넌트 수정
- router에 /post/user/:id 추가 ( 특정 유저 게시글 리스트 )
- MainBannerWrap에서 사용하는 API response 타입 export

### 스크린샷 (선택)## 💬리뷰 요구사항(선택)> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
![image](https://github.com/user-attachments/assets/eb784a03-9f89-474b-97e0-613f94fbabe7)

