### PR TITLE
Feat: 페이지 이동시 Scroll이 해당 페이지의 맨위로

### DIFF
--- a/src/components/Common/ScrollToTop.tsx
+++ b/src/components/Common/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -12,17 +12,21 @@ import RankPage from "@pages/RankPage";
 import SearchPage from "@pages/SearchPage";
 import { createBrowserRouter, Outlet } from "react-router-dom";
 import { ProtectedRoute } from "@components/Common/ProtectedRoute";
+import { ScrollToTop } from "@components/Common/ScrollToTop";
 
 export const router = createBrowserRouter([
   {
     path: "/",
     element: (
       <>
-        <Header />
-        <main id="wrapper">
-          <Outlet />
-        </main>
-        <Footer />
+        <ScrollToTop />
+        <div>
+          <Header />
+          <main id="wrapper">
+            <Outlet />
+          </main>
+          <Footer />
+        </div>
       </>
     ),
     errorElement: <ErrorPage />,


### PR DESCRIPTION
## #️⃣연관된 이슈
#209


## 📝작업 내용
- 페이지 이동 시 전 페이지의 스크롤 위치가 고정되어 이동 되는 부분이 있어, 페이지 이동 시 Scroll이 가장 위로 가도록 컴포넌트를 추가했습니다

