### PR TITLE
172 feature postpage

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-intersection-observer": "^9.13.1",
     "react-quill": "^2.0.0",
     "react-router-dom": "^6.27.0",
+    "react-select": "^5.8.2",
     "react-syntax-highlighter": "^15.6.1",
     "socket.io-client": "^4.8.1",
     "styled-components": "^6.1.13",

--- a/src/components/Common/PostListItem.tsx
+++ b/src/components/Common/PostListItem.tsx
@@ -68,10 +68,10 @@ export const PostListItem = ({ postItem, ranked }: { postItem: TPost; ranked?: n
               </div>
             </div>
             <Link
-              to={`/post/user/${postItem.author.userId}`}
+              to={`/post/user/${postItem.author?._id}`}
               className="flex w-full gap-1 text-12 text-primary 2xs:w-auto md:text-14"
             >
-              <div className="underline">{postItem.author.userId}</div>
+              <div className="underline">{postItem.author?.userId}</div>
             </Link>
           </div>
         </div>

--- a/src/components/MainPage/MainSection.tsx
+++ b/src/components/MainPage/MainSection.tsx
@@ -39,8 +39,8 @@ export const MainSection = () => {
           }
         }}
       >
-        {banners.map(({ banner, color }) => (
-          <SwiperSlide className="transition-transform hover:scale-105">
+        {banners.map(({ banner, color }, i) => (
+          <SwiperSlide key={i} className="transition-transform hover:scale-105">
             <ErrorBoundary fallback={<MainBannerSkeleton isError={true} />}>
               <Suspense fallback={<MainBannerSkeleton />}>
                 <MainBanner color={color}>{React.createElement(banner)}</MainBanner>

--- a/src/components/MainPage/PostSectionSkeleton.tsx
+++ b/src/components/MainPage/PostSectionSkeleton.tsx
@@ -9,8 +9,8 @@ export const PostSectionSkeleton = ({ isError }: PostSectionSkeletonProps) => {
   return (
     <div className={`px-3 py-5 ${isError ? "" : "animate-pulse"}`}>
       {[1, 2, 3].map((v) => (
-        <div className="p-2.5">
-          <PostItemSkeleton bgColor={bgColor} key={v} />
+        <div key={v} className="p-2.5">
+          <PostItemSkeleton bgColor={bgColor} />
         </div>
       ))}
     </div>

--- a/src/components/PostPage/PostPageHeader.tsx
+++ b/src/components/PostPage/PostPageHeader.tsx
@@ -1,0 +1,41 @@
+import Select from "react-select";
+
+type PostPageHeaderProps = {
+  order: "recent" | "popular";
+  setOrder: React.Dispatch<React.SetStateAction<"recent" | "popular">>;
+  id?: string;
+};
+export const PostPageHeader = ({ order, setOrder, id }: PostPageHeaderProps) => {
+  const options = [
+    { value: "recent", label: "최신순" },
+    { value: "popular", label: "인기순" }
+  ];
+  const headerText = { recent: "최신", popular: "인기" };
+
+  return (
+    <div className="flex w-full flex-col p-8 pb-0">
+      <div className="flex w-full items-center justify-between">
+        <div className="text-24">
+          {id && `${id}님의 `}
+          {headerText[order]} 게시글
+        </div>
+        <Select
+          options={options}
+          isSearchable={false}
+          defaultValue={options[0]}
+          unstyled
+          onChange={(selectedOption) =>
+            setOrder(selectedOption ? (selectedOption.value as "recent" | "popular") : "recent")
+          }
+          classNames={{
+            container: ({ isFocused }) =>
+              `rounded border-2 border-solid border-primary gap-4 z-10 transition-shadow ${isFocused && "shadow"}`,
+            menu: () => " rounded mt-2 shadow  text-20 text-secondary bg-white-pure",
+            option: () => "p-4 hover:bg-primary hover:text-white-sub",
+            control: () => "h-[3.125rem] w-[12.5rem] border-none rounded-[10px] px-4 text-20 text-secondary"
+          }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/PostPage/PostPageHeader.tsx
+++ b/src/components/PostPage/PostPageHeader.tsx
@@ -1,23 +1,31 @@
 import Select from "react-select";
 
 type PostPageHeaderProps = {
-  order: "recent" | "popular";
-  setOrder: React.Dispatch<React.SetStateAction<"recent" | "popular">>;
+  sort: "latest" | "views";
+  setSort: React.Dispatch<React.SetStateAction<"latest" | "views">>;
   id?: string;
 };
-export const PostPageHeader = ({ order, setOrder, id }: PostPageHeaderProps) => {
+export const PostPageHeader = ({ sort, setSort, id }: PostPageHeaderProps) => {
   const options = [
-    { value: "recent", label: "최신순" },
-    { value: "popular", label: "인기순" }
+    { value: "latest", label: "최신순" },
+    { value: "views", label: "인기순" }
   ];
-  const headerText = { recent: "최신", popular: "인기" };
-
+  const headerText = { latest: "최신", views: "인기" };
+  console.log(id);
   return (
     <div className="flex w-full flex-col p-8 pb-0">
       <div className="flex w-full items-center justify-between">
-        <div className="text-24">
-          {id && `${id}님의 `}
-          {headerText[order]} 게시글
+        <div className="flex flex-col gap-4 text-24">
+          {id === undefined ? (
+            ""
+          ) : id === "" ? (
+            <div className="h-6 w-20"> </div>
+          ) : (
+            <div className="flex">
+              <div className="font-bold text-secondary">{id}</div>님의
+            </div>
+          )}
+          {headerText[sort]} 게시글
         </div>
         <Select
           options={options}
@@ -25,7 +33,7 @@ export const PostPageHeader = ({ order, setOrder, id }: PostPageHeaderProps) => 
           defaultValue={options[0]}
           unstyled
           onChange={(selectedOption) =>
-            setOrder(selectedOption ? (selectedOption.value as "recent" | "popular") : "recent")
+            setSort(selectedOption ? (selectedOption.value as "latest" | "views") : "latest")
           }
           classNames={{
             container: ({ isFocused }) =>

--- a/src/components/PostPage/PostPageList.tsx
+++ b/src/components/PostPage/PostPageList.tsx
@@ -1,0 +1,59 @@
+import { Loading } from "@components/Common/Loading";
+import { PostList } from "@components/Common/PostList";
+import { CommonPostResponseProps } from "@customTypes/post";
+import useSuspenseInfinite from "@hooks/useSuspenseInfinite";
+import { getPopularPosts } from "@services/post/getPopularPosts";
+import { getPosts } from "@services/post/getPosts";
+import { getUserPosts } from "@services/user/getUserPosts";
+import { useCallback, useRef } from "react";
+type PostPageUserPostListProps = {
+  order: "recent" | "popular";
+  userId?: string;
+};
+
+export const PostPageList = ({ order, userId }: PostPageUserPostListProps) => {
+  const fc = order === "popular" ? getPopularPosts : getPosts;
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useSuspenseInfinite<CommonPostResponseProps>({
+    key: ["PostPage", order, userId],
+    fetchFunc: userId
+      ? ({ page, limit }) => getUserPosts({ page, limit, order: order, userId: userId })
+      : ({ page, limit }) => fc({ page, limit }),
+    limit: 10
+  });
+
+  const posts = data.pages.flatMap((page) => page.posts);
+
+  const observer = useRef<IntersectionObserver | null>(null);
+  const lastPostElementRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (isFetchingNextPage) return;
+      if (observer.current) observer.current.disconnect();
+      observer.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasNextPage) {
+          fetchNextPage();
+        }
+      });
+      if (node) observer.current.observe(node);
+    },
+    [isFetchingNextPage, fetchNextPage, hasNextPage]
+  );
+
+  return (
+    <div>
+      <div className="flex w-full items-center justify-between p-8">
+        <div className="text-20">{data?.pages[0].totalPosts}개의 질문</div>
+      </div>
+      {posts && (
+        <>
+          <PostList posts={posts} />
+          <div ref={lastPostElementRef}></div>
+        </>
+      )}
+      {isFetchingNextPage && (
+        <div className="flex">
+          <Loading />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/PostPage/PostPageListSkeleton.tsx
+++ b/src/components/PostPage/PostPageListSkeleton.tsx
@@ -1,0 +1,22 @@
+import { PostItemSkeleton } from "@components/Common/PostItemSkeleton";
+
+type PostPageSkeletonProps = {
+  isError?: boolean;
+};
+export const PostPageSkeleton = ({ isError = false }: PostPageSkeletonProps) => {
+  const bgColor = isError ? "bg-pink opacity-40" : "bg-lightgray animate-pulse";
+
+  return (
+    <div>
+      <div className="flex w-full items-center justify-between p-8">
+        <div className={`h-5 w-80 rounded ${bgColor} `}></div>
+      </div>
+
+      <div className="px-3 py-5">
+        <div className="p-2.5">
+          <PostItemSkeleton bgColor={bgColor} />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/hooks/useSuspenseInfinite.ts
+++ b/src/hooks/useSuspenseInfinite.ts
@@ -1,0 +1,35 @@
+import { DevDependency } from "@customTypes/post";
+import { QueryKey, useSuspenseInfiniteQuery } from "@tanstack/react-query";
+
+type FetchParams = { page: number; limit: number } & Record<string, string | number | DevDependency[]>;
+
+type UseInfiniteProps<T> = {
+  key: QueryKey;
+  fetchFunc: (params: FetchParams) => Promise<T>;
+  limit?: number; // 기본 limit 값을 설정할 수 있도록 추가
+};
+
+export default function useSuspenseInfinite<
+  T extends {
+    currentPage: number;
+    totalPages: number;
+  }
+>({ key, fetchFunc, limit = 10 }: UseInfiniteProps<T>) {
+  // 페이지 이동 시 지연을 처리하는 함수
+  const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error } = useSuspenseInfiniteQuery<T, Error>(
+    {
+      queryKey: key,
+      queryFn: async ({ pageParam = 1 }) => {
+        if (pageParam !== 1) await delay(1000); // 페이지가 1이 아닐 때만 지연 추가
+        return fetchFunc({ page: pageParam as number, limit });
+      },
+      getNextPageParam: (lastPage) =>
+        lastPage.currentPage < lastPage.totalPages ? lastPage.currentPage + 1 : undefined,
+      initialPageParam: 1
+    }
+  );
+
+  return { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error };
+}

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -7,21 +7,20 @@ import { useParams } from "react-router-dom";
 
 export default function PostPage() {
   const { id } = useParams<{ id: string }>();
-  const [order, setOrder] = useState<"recent" | "popular">("recent");
+  const [sort, setSort] = useState<"latest" | "views">("latest");
+  const [userId, setUserId] = useState<string>("");
   return (
-    <>
-      <div className="m-auto max-w p-20">
-        {id ? (
-          <PostPageHeader id={id} order={order} setOrder={setOrder} />
-        ) : (
-          <PostPageHeader order={order} setOrder={setOrder} />
-        )}
-        <ErrorBoundary fallback={<PostPageSkeleton isError={true} />}>
-          <Suspense fallback={<PostPageSkeleton />}>
-            {id ? <PostPageList order={order} userId={id} /> : <PostPageList order={order} />}
-          </Suspense>
-        </ErrorBoundary>
-      </div>
-    </>
+    <div className="m-auto max-w p-20">
+      {id ? (
+        <PostPageHeader id={userId} sort={sort} setSort={setSort} />
+      ) : (
+        <PostPageHeader sort={sort} setSort={setSort} />
+      )}
+      <ErrorBoundary fallback={<PostPageSkeleton isError={true} />}>
+        <Suspense fallback={<PostPageSkeleton />}>
+          {id ? <PostPageList sort={sort} id={id} setUserId={setUserId} /> : <PostPageList sort={sort} />}
+        </Suspense>
+      </ErrorBoundary>
+    </div>
   );
 }

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -1,3 +1,27 @@
+import { PostPageHeader } from "@components/PostPage/PostPageHeader";
+import { PostPageList } from "@components/PostPage/PostPageList";
+import { PostPageSkeleton } from "@components/PostPage/PostPageListSkeleton";
+import { Suspense, useState } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { useParams } from "react-router-dom";
+
 export default function PostPage() {
-  return <div>PostPage</div>;
+  const { id } = useParams<{ id: string }>();
+  const [order, setOrder] = useState<"recent" | "popular">("recent");
+  return (
+    <>
+      <div className="m-auto max-w p-20">
+        {id ? (
+          <PostPageHeader id={id} order={order} setOrder={setOrder} />
+        ) : (
+          <PostPageHeader order={order} setOrder={setOrder} />
+        )}
+        <ErrorBoundary fallback={<PostPageSkeleton isError={true} />}>
+          <Suspense fallback={<PostPageSkeleton />}>
+            {id ? <PostPageList order={order} userId={id} /> : <PostPageList order={order} />}
+          </Suspense>
+        </ErrorBoundary>
+      </div>
+    </>
+  );
 }

--- a/src/services/user/getUserPosts.ts
+++ b/src/services/user/getUserPosts.ts
@@ -1,17 +1,26 @@
 import { ErrorResponse } from "@customTypes/errorResponse";
+import { PaginationRequestProps } from "@customTypes/pagination";
 import { CommonPostResponseProps } from "@customTypes/post";
 import axiosInstance from "@services/axiosInstance";
 import axios, { AxiosError } from "axios";
 
 type GetUserPostsRequestProps = {
   userId: string;
-};
+  order: "recent" | "popular";
+} & PaginationRequestProps;
 
 type GetUserPostsResponseProps = CommonPostResponseProps;
 
-export async function getUserPosts({ userId }: GetUserPostsRequestProps): Promise<GetUserPostsResponseProps> {
+export async function getUserPosts({
+  page,
+  limit,
+  order,
+  userId
+}: GetUserPostsRequestProps): Promise<GetUserPostsResponseProps> {
   try {
-    const response = await axiosInstance.get<GetUserPostsResponseProps>(`/user/${userId}/post`);
+    const response = await axiosInstance.get<GetUserPostsResponseProps>(`/user/${userId}/post`, {
+      params: { page, limit, order }
+    });
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {

--- a/src/services/user/getUserPosts.ts
+++ b/src/services/user/getUserPosts.ts
@@ -6,20 +6,20 @@ import axios, { AxiosError } from "axios";
 
 type GetUserPostsRequestProps = {
   userId: string;
-  order: "recent" | "popular";
+  sort: "latest" | "views";
 } & PaginationRequestProps;
 
-type GetUserPostsResponseProps = CommonPostResponseProps;
+type GetUserPostsResponseProps = CommonPostResponseProps & { userId: string };
 
 export async function getUserPosts({
   page,
   limit,
-  order,
+  sort,
   userId
 }: GetUserPostsRequestProps): Promise<GetUserPostsResponseProps> {
   try {
     const response = await axiosInstance.get<GetUserPostsResponseProps>(`/user/${userId}/post`, {
-      params: { page, limit, order }
+      params: { page, limit, sort }
     });
     return response.data;
   } catch (error) {


### PR DESCRIPTION
## #️⃣연관된 이슈
#172 


## 📝작업 내용
1. PostPage 추가
2. package에 react-select 추가 
3. PostPageList의 대체컴포넌트 추가
4. **useInfinite에서 suspense를 지원하는 useSuspenseInfinite 추가 
   -> useInfinite를 이미 사용하고 있는 다른 페이지가 있어서 별도의 파일로 추가 했습니다. 
   -> useSuspenseInfinite는 useInfinite와 다르게 key를 Querykey의 형태 그대로 받아옵니다.**

5. map함수로 생성한 컴포넌트 중 key가 존재하지 않는 문제 수정
6. PostListItem의 author가 잘못된 대상을 가리키고 있던 문제 수정
7. getUserPosts에 페이지네이션을 위한 파라미터를 추가



### 스크린샷 (선택)## 💬리뷰 요구사항(선택)> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
![image](https://github.com/user-attachments/assets/e87640fb-b473-4095-b895-24322937f2eb)
![image](https://github.com/user-attachments/assets/76370501-c0ee-4316-8608-f2cc4733e1f6)
![image](https://github.com/user-attachments/assets/1c770d57-f66e-4ebc-ac67-9495e346edf7)
![image](https://github.com/user-attachments/assets/80d2be9e-f00a-4069-8083-7af9de2b3bf4)


