### PR TITLE
298 feature postpage sort

### DIFF
--- a/src/components/MainPage/MainBannerSkeleton.tsx
+++ b/src/components/MainPage/MainBannerSkeleton.tsx
@@ -1,6 +1,6 @@
-type MainBannerSkeletonProps = { isError?: boolean };
+type MainBannerSkeletonProps = { isError?: boolean; error?: string };
 
-export const MainBannerSkeleton = ({ isError = false }: MainBannerSkeletonProps) => {
+export const MainBannerSkeleton = ({ isError = false, error }: MainBannerSkeletonProps) => {
   const bgColor = isError ? "bg-pink " : "bg-lightgray animate-pulse";
-  return <div className={`flex h-52 rounded-lg ${bgColor} shadow`}></div>;
+  return <div className={`flex h-52 rounded-lg ${bgColor} p-4 text-16 text-white-sub shadow`}>{error}</div>;
 };

--- a/src/components/MainPage/MainSection.tsx
+++ b/src/components/MainPage/MainSection.tsx
@@ -50,7 +50,7 @@ export const MainSection = () => {
       >
         {banners.map(({ banner, color }, i) => (
           <SwiperSlide key={i} className="transition-transform md:hover:scale-105">
-            <ErrorBoundary fallback={<MainBannerSkeleton isError={true} />}>
+            <ErrorBoundary fallbackRender={({ error }) => <MainBannerSkeleton error={error.message} isError={true} />}>
               <Suspense fallback={<MainBannerSkeleton />}>
                 <MainBanner color={color}>{React.createElement(banner)}</MainBanner>
               </Suspense>

--- a/src/components/MainPage/RecentPostSection.tsx
+++ b/src/components/MainPage/RecentPostSection.tsx
@@ -8,7 +8,7 @@ export const RecentPostSection = () => {
     <div className="m-auto max-w px-4 py-3">
       <div className="flex items-center justify-between border-b-2 border-solid border-lightgray py-4">
         <div className="text-16 md:text-24">👀 최신 게시글 </div>
-        <Link to="/post" className="text-12 text-secondary md:text-16">
+        <Link to="/post/recent" className="text-12 text-secondary md:text-16">
           더보기-&gt;
         </Link>
       </div>

--- a/src/components/PostPage/PostPageHeader.tsx
+++ b/src/components/PostPage/PostPageHeader.tsx
@@ -1,8 +1,10 @@
+import { useSortStore } from "@stores/sortStore";
+
 type PostPageHeaderProps = {
-  sort: "latest" | "views";
   id?: string;
 };
-export const PostPageHeader = ({ sort, id }: PostPageHeaderProps) => {
+export const PostPageHeader = ({ id }: PostPageHeaderProps) => {
+  const { sort } = useSortStore();
   const headerText = { latest: "최신", views: "인기" };
   return (
     <div className="flex w-full flex-col">

--- a/src/components/PostPage/PostPageList.tsx
+++ b/src/components/PostPage/PostPageList.tsx
@@ -7,15 +7,15 @@ import { getPosts } from "@services/post/getPosts";
 import { getUserPosts } from "@services/user/getUserPosts";
 import { useCallback, useRef } from "react";
 import { CgArrowsExchangeAltV } from "react-icons/cg";
+import { useSortStore } from "@stores/sortStore";
 type PostPageUserPostListProps = {
-  sort: "latest" | "views";
   id?: string;
-  setSort: React.Dispatch<React.SetStateAction<"latest" | "views">>;
   setUserId?: React.Dispatch<React.SetStateAction<string>>;
 };
-export const PostPageList = ({ sort, id, setUserId, setSort }: PostPageUserPostListProps) => {
+export const PostPageList = ({ id, setUserId }: PostPageUserPostListProps) => {
+  const { sort } = useSortStore();
+  const { setSort } = useSortStore();
   const fc = sort === "views" ? getPopularPosts : getPosts;
-
   const headerText = { latest: "최신", views: "인기" };
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useSuspenseInfinite<
     CommonPostResponseProps & { userId?: string }

--- a/src/components/PostPage/PostPageListSkeleton.tsx
+++ b/src/components/PostPage/PostPageListSkeleton.tsx
@@ -8,11 +8,11 @@ export const PostPageSkeleton = ({ isError = false }: PostPageSkeletonProps) => 
 
   return (
     <div>
-      <div className="flex w-full items-center justify-between p-8">
-        <div className={`h-5 w-24 rounded ${bgColor} `}></div>
+      <div className="flex w-full items-center justify-between pt-[3.25rem]">
+        <div className={`h-5 w-24 rounded ${bgColor} pt-1`}></div>
       </div>
 
-      <div className="min-h-screen px-3 py-5">
+      <div className="min-h-screen py-4">
         <div className="p-2.5">
           <PostItemSkeleton bgColor={bgColor} />
         </div>

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -4,21 +4,27 @@ import { PostPageSkeleton } from "@components/PostPage/PostPageListSkeleton";
 import { Suspense, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useParams } from "react-router-dom";
+import { useSortStore } from "@stores/sortStore";
+import { useEffect } from "react";
 
-export default function PostPage() {
+type PostPageProps = {
+  defaultSort?: "latest" | "views";
+};
+export default function PostPage({ defaultSort }: PostPageProps) {
   const { id } = useParams<{ id: string }>();
-  const [sort, setSort] = useState<"latest" | "views">("latest");
   const [userId, setUserId] = useState<string>("");
+  const { setSort } = useSortStore();
+  useEffect(() => {
+    if (defaultSort) {
+      setSort(defaultSort);
+    }
+  }, [defaultSort, setSort]);
   return (
     <div className="m-auto max-w p-4 pt-12">
-      {id ? <PostPageHeader sort={sort} id={userId} /> : <PostPageHeader sort={sort} />}
+      {id ? <PostPageHeader id={userId} /> : <PostPageHeader />}
       <ErrorBoundary fallback={<PostPageSkeleton isError={true} />}>
         <Suspense fallback={<PostPageSkeleton />}>
-          {id ? (
-            <PostPageList setSort={setSort} sort={sort} id={id} setUserId={setUserId} />
-          ) : (
-            <PostPageList sort={sort} setSort={setSort} />
-          )}
+          {id ? <PostPageList id={id} setUserId={setUserId} /> : <PostPageList />}
         </Suspense>
       </ErrorBoundary>
     </div>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -44,8 +44,12 @@ export const router = createBrowserRouter([
         element: <PostPage />
       },
       {
+        path: "/post/recent",
+        element: <PostPage defaultSort="latest" />
+      },
+      {
         path: "/post/popular",
-        element: <PostPage />
+        element: <PostPage defaultSort="views" />
       },
       {
         path: "/post/user/:id",

--- a/src/stores/sortStore.ts
+++ b/src/stores/sortStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+type SortStore = {
+  sort: "latest" | "views";
+  setSort: (sort: "latest" | "views") => void;
+};
+
+export const useSortStore = create<SortStore>((set) => ({
+  sort: "latest",
+  setSort: (sort: "latest" | "views") => set({ sort })
+}));


### PR DESCRIPTION
## #️⃣연관된 이슈
#298 


## 📝작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
1. 정렬 방식을 전역상태로 변경 - 페이지를 이동해도 정렬 방식이 유지됩니다.
2. MainPage의 최신/인기 게시글의 더보기 버튼 클릭 시 해당 방식의 정렬이 초기값으로 설정된 채로 페이지가 이동되도록 변경
3. MainBanner 오류 발생 시 오류 내용 간략하게 출력
4. PostPageList 대체 컴포넌트의 레이아웃을 원본과 유사하게 변경

### 스크린샷 (선택)## 💬리뷰 요구사항(선택)> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!--  ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
![image](https://github.com/user-attachments/assets/89baeaad-dd0e-44c8-a292-fb58b00bc57c)

